### PR TITLE
Fix multiple compilation errors after merge

### DIFF
--- a/Forms/LoginForm.cs
+++ b/Forms/LoginForm.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
-using S3FileManager.Models;
-using S3FileManager.Services;
+using AWSS3Sync.Models;
+using AWSS3Sync.Services;
 
-namespace S3FileManager
+namespace AWSS3Sync
 {
     public partial class LoginForm : Form
     {

--- a/Forms/MainForm.Events.cs
+++ b/Forms/MainForm.Events.cs
@@ -4,9 +4,10 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
+using AWSS3Sync.Services;
 
-namespace S3FileManager
+namespace AWSS3Sync
 {
     public partial class MainForm
     {

--- a/Forms/MainForm.Helpers.cs
+++ b/Forms/MainForm.Helpers.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
 
-namespace S3FileManager
+namespace AWSS3Sync
 {
     public partial class MainForm
     {

--- a/Forms/MainForm.Operations.cs
+++ b/Forms/MainForm.Operations.cs
@@ -5,9 +5,9 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
 
-namespace S3FileManager
+namespace AWSS3Sync
 {
     public partial class MainForm
     {
@@ -39,7 +39,7 @@ namespace S3FileManager
             try
             {
                 // Fetch direct descendants
-                var files = await _s3Service.ListFilesAsync(parentNodeInfo.Path, _currentUser.Role);
+                var files = await _s3Service.ListFilesAsync(_currentUser.Role, parentNodeInfo.Path);
 
                 this.Invoke(new Action(() =>
                 {

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -6,10 +6,10 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using S3FileManager.Models;
-using S3FileManager.Services;
+using AWSS3Sync.Models;
+using AWSS3Sync.Services;
 
-namespace S3FileManager
+namespace AWSS3Sync
 {
     public partial class MainForm : Form
     {

--- a/Forms/ProgressForm.cs
+++ b/Forms/ProgressForm.cs
@@ -1,7 +1,7 @@
 ﻿using System.Drawing;
 using System.Windows.Forms;
 
-namespace S3FileManager
+namespace AWSS3Sync
 {
     public class ProgressForm : Form
     {

--- a/Forms/RoleSelectionForm.cs
+++ b/Forms/RoleSelectionForm.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
 
-namespace S3FileManager
+namespace AWSS3Sync
 {
     public partial class RoleSelectionForm : Form
     {

--- a/Forms/SupportingForms.cs
+++ b/Forms/SupportingForms.cs
@@ -7,10 +7,10 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Amazon;
 using Amazon.S3;
-using S3FileManager.Models;
-using S3FileManager.Services;
+using AWSS3Sync.Models;
+using AWSS3Sync.Services;
 
-namespace S3FileManager
+namespace AWSS3Sync
 {
     // Sync Direction Selection
     public enum SyncDirection
@@ -981,8 +981,7 @@ namespace S3FileManager
                 var s3Items = selectedFiles.Select(key => new S3FileItem
                 {
                     Key = key,
-                    AccessRoles = new List<UserRole> { UserRole.Administrator },
-                    IsDirectory = key.EndsWith("/")
+                    AccessRoles = new List<UserRole> { UserRole.Administrator }
                 }).ToList();
 
                 // Show permission management form

--- a/Forms/SyncDirectionForm.cs
+++ b/Forms/SyncDirectionForm.cs
@@ -2,7 +2,7 @@
 using System.Drawing;
 using System.Windows.Forms;
 
-namespace S3FileManager.Forms
+namespace AWSS3Sync.Forms
 {
     public enum SyncDirection
     {

--- a/Forms/VersionHistoryForm.cs
+++ b/Forms/VersionHistoryForm.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
-using S3FileManager.Models;
-using S3FileManager.Services;
+using AWSS3Sync.Models;
+using AWSS3Sync.Services;
 
-namespace S3FileManager.Forms
+namespace AWSS3Sync.Forms
 {
     public class VersionHistoryForm : Form
     {

--- a/Models/AppConfig.cs
+++ b/Models/AppConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace S3FileManager.Models
+namespace AWSS3Sync.Models
 {
     public class AppConfig
     {

--- a/Models/FileComparisonResult.cs
+++ b/Models/FileComparisonResult.cs
@@ -1,4 +1,4 @@
-namespace S3FileManager.Models
+namespace AWSS3Sync.Models
 {
     public enum ComparisonStatus
     {

--- a/Models/FileItem.cs
+++ b/Models/FileItem.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace S3FileManager.Models
+namespace AWSS3Sync.Models
 {
     public class LocalFileItem
     {
@@ -63,6 +63,18 @@ namespace S3FileManager.Models
             Name = name;
             Path = path;
             IsDirectory = false;
+            Size = size;
+            LastModified = lastModified;
+            VersionId = versionId;
+            IsS3 = true;
+        }
+
+        // Overloaded constructor to resolve ambiguity
+        public FileNode(string name, string path, bool isDirectory, long size, DateTime lastModified, string versionId)
+        {
+            Name = name;
+            Path = path;
+            IsDirectory = isDirectory;
             Size = size;
             LastModified = lastModified;
             VersionId = versionId;

--- a/Models/LocalFileInfo.cs
+++ b/Models/LocalFileInfo.cs
@@ -1,4 +1,4 @@
-namespace S3FileManager.Models
+namespace AWSS3Sync.Models
 {
     public class LocalFileInfo
     {

--- a/Models/UserRole.cs
+++ b/Models/UserRole.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace S3FileManager.Models
+namespace AWSS3Sync.Models
 {
     public enum UserRole
     {

--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Windows.Forms;
 
-namespace S3FileManager
+namespace AWSS3Sync
 {
     public class Program
     {

--- a/Services/ComparisonService.cs
+++ b/Services/ComparisonService.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
 
-namespace S3FileManager.Services
+namespace AWSS3Sync.Services
 {
     public class ComparisonService
     {

--- a/Services/ConfigurationService.cs
+++ b/Services/ConfigurationService.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Windows.Forms;
 using Newtonsoft.Json;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
 
-namespace S3FileManager.Services
+namespace AWSS3Sync.Services
 {
     public class ConfigurationService
     {

--- a/Services/FileService.cs
+++ b/Services/FileService.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
 
-namespace S3FileManager.Services
+namespace AWSS3Sync.Services
 {
     public class FileService
     {

--- a/Services/MetadataService.cs
+++ b/Services/MetadataService.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Amazon.S3;
 using Amazon.S3.Model;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
 
-namespace S3FileManager.Services
+namespace AWSS3Sync.Services
 {
     public class MetadataService
     {

--- a/Services/S3Service.cs
+++ b/Services/S3Service.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 using Amazon;
 using Amazon.S3;
 using Amazon.S3.Model;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
 
-namespace S3FileManager.Services
+namespace AWSS3Sync.Services
 {
     public class S3Service : IDisposable
     {
@@ -353,14 +353,15 @@ namespace S3FileManager.Services
                     versions.Add(new FileNode(
                         version.Key,
                         version.Key,
+                        false,
                         version.Size,
                         version.LastModified,
                         version.VersionId
                     ));
                 }
-                request.NextKeyMarker = response.NextKeyMarker;
-                request.NextVersionIdMarker = response.NextVersionIdMarker;
-            } while (response.IsTruncated);
+                request.KeyMarker = response.NextKeyMarker;
+                request.VersionIdMarker = response.NextVersionIdMarker;
+            } while (response.IsTruncated == true);
 
             return versions;
         }

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -6,9 +6,9 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Windows.Forms;
 using Newtonsoft.Json;
-using S3FileManager.Models;
+using AWSS3Sync.Models;
 
-namespace S3FileManager.Services
+namespace AWSS3Sync.Services
 {
     public class UserService
     {


### PR DESCRIPTION
This commit fixes a series of compilation errors that arose after a merge. The fixes include:
- Standardizing namespaces to `AWSS3Sync` across the project.
- Correcting swapped arguments in a method call.
- Removing an assignment to a read-only property.
- Fixing incorrect property names in an AWS SDK request.
- Resolving an ambiguous constructor overload by adding a new constructor.