### PR TITLE
Fix: Resolve build errors related to missing field and async method

### DIFF
--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -26,7 +26,8 @@ namespace AWSS3Sync
         // Performance optimization: Cache and selection tracking
         private readonly Dictionary<string, bool> _s3CheckedItems = new Dictionary<string, bool>();
         private readonly Dictionary<string, bool> _localCheckedItems = new Dictionary<string, bool>();
-		
+        private bool _isUpdatingTree = false;
+
         // UI controls that need to be accessed across methods
         private Label previewInfoLabel = null!;
         private RichTextBox previewTextBox = null!;

--- a/Tests/UnifiedAuthTests.cs
+++ b/Tests/UnifiedAuthTests.cs
@@ -10,20 +10,23 @@ namespace AWSS3Sync.Tests
     /// </summary>
     public class UnifiedAuthTests
     {
-        public static void RunBasicTests()
+        public static Task RunBasicTests()
         {
-            Console.WriteLine("Starting Unified Authentication System Tests...\n");
+            return Task.Run(() =>
+            {
+                Console.WriteLine("Starting Unified Authentication System Tests...\n");
 
-            // Test 1: UnifiedUser creation from local user
-            TestUnifiedUserFromLocal();
+                // Test 1: UnifiedUser creation from local user
+                TestUnifiedUserFromLocal();
 
-            // Test 2: Authentication result creation
-            TestAuthenticationResults();
+                // Test 2: Authentication result creation
+                TestAuthenticationResults();
 
-            // Test 3: UnifiedAuthService initialization
-            TestUnifiedAuthServiceInitialization();
+                // Test 3: UnifiedAuthService initialization
+                TestUnifiedAuthServiceInitialization();
 
-            Console.WriteLine("\nAll tests completed!");
+                Console.WriteLine("\nAll tests completed!");
+            });
         }
 
         private static void TestUnifiedUserFromLocal()


### PR DESCRIPTION
This commit addresses three build errors:
1.  Two CS0103 errors in `Forms/MainForm.Helpers.cs` caused by a missing `_isUpdatingTree` field. The field has been declared in `Forms/MainForm.cs`.
2.  One CS4008 error in `Program.cs` caused by awaiting a `void` method. The `RunBasicTests` method in `Tests/UnifiedAuthTests.cs` has been updated to return a `Task`.